### PR TITLE
Remove 4x vmwaretools when installing 5x

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -247,6 +247,13 @@ class vmwaretools (
           before => Package[$package_real],
         }
 
+        if $package_real == $vmwaretools::params::package_name_5x {
+          exec { "yum -y remove ${vmwaretools::params::package_name_4x_kmod}":
+            onlyif => "rpm -q ${vmwaretools::params::package_name_4x_kmod}",
+            before => Package[$package_real],
+          }
+        }
+
         exec { 'vmware-uninstall-tools':
           command => '/usr/bin/vmware-uninstall-tools.pl && rm -rf /usr/lib/vmware-tools',
           path    => '/bin:/sbin:/usr/bin:/usr/sbin',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -171,6 +171,7 @@ class vmwaretools::params {
             }
           }
           $package_name_4x = 'vmware-tools-nox'
+          $package_name_4x_kmod ='vmware-open-vm-tools-kmod'
           # TODO: OSP 5.0+ rhel5 i386 also has vmware-tools-esx-kmods-PAE
           $package_name_5x = [
             'vmware-tools-esx-nox',
@@ -211,6 +212,7 @@ class vmwaretools::params {
             }
           }
           $package_name_4x = 'vmware-tools-nox'
+          $package_name_4x_kmod = 'vmware-open-vm-tools-kmod'
           $package_name_5x = [
             'vmware-tools-esx-nox',
             'vmware-tools-esx-kmods-default',


### PR DESCRIPTION
I'm trying to use your module to upgrade my existing infrastructure from vmwaretools 4x to 5x but sadly it doesn't work without removing the vmwaretools 4x explicitly first because its not recognized as an upgrade (package names changed). That's why I try to work around the problem by removing the old package with yum remove. I tried using package absent or package purged but that will lead to either not removing the packages because of dependencies or when using purged to "Package created" messages on on all next runs (https://tickets.puppetlabs.com/browse/PUP-1352).
I'm using the kmod module for yum remove  because the if you'd use the vmware-tools-nox it would only remove that and not the other vmware 4x packages, when removing the kmod package all others get removed because they depend on it.

I've tested it on rhel 6.

Greetings
Klaas
